### PR TITLE
add d-flex and flex-column classes

### DIFF
--- a/docs/contribute.html
+++ b/docs/contribute.html
@@ -14,7 +14,7 @@
 </head>
 
 <body>
-    <div id="pagewidth" class="contribute">
+    <div id="pagewidth" class="contribute d-flex flex-column">
 
         <!--================-->
         <!--===HEADER/NAV===-->


### PR DESCRIPTION
The body div was missing the d-flex and flex-column classes, preventing the footer from touching the bottom of the window on tall viewports (ignored the min-height=100vh in css)
Fixes #57