### PR TITLE
remove 'row' class that caused div overflow

### DIFF
--- a/docs/resources.html
+++ b/docs/resources.html
@@ -54,7 +54,7 @@
         <!--=================-->
 
         <section class="container body-section flex-fill my-0 py-5 px-4" data-bs-theme="dark">
-            <div id="twoColumnLayout" class="row center contentspace pb-4">
+            <div id="twoColumnLayout" class="center contentspace pb-4">
                 <h1>Resources</h1>
                 <div class="columns">
                     <div class="twoThird">


### PR DESCRIPTION
Removed a class I added back in #54 that compacted all div tags. Caused overflow to happen on lower divs, hiding the footer.
Fixes #60